### PR TITLE
Pushing targets to s3 

### DIFF
--- a/.github/workflows/targets.yaml
+++ b/.github/workflows/targets.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: targets-to-bucket
+          ref: prod
       - name: Generate targets
         shell: Rscript {0}
         run: |

--- a/.github/workflows/targets.yaml
+++ b/.github/workflows/targets.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: prod
+          ref: targets-to-bucket
       - name: Generate targets
         shell: Rscript {0}
         run: |

--- a/challenge_configuration.yaml
+++ b/challenge_configuration.yaml
@@ -25,7 +25,8 @@ target_metadata_gsheet: https://docs.google.com/spreadsheets/d/10YTX9ae_C1rFdLgE
 targets_thumbnail: 'https://raw.githubusercontent.com/eco4cast/neon4cast-ci/main/catalog/thumbnail_plots/neon_stream.jpg'
 targets_thumbnail_title: 'Test Image'
 targets_path: 'catalog/targets/'
-##
+# to here
+targets_file_name: 'river-chl-targets.csv.gz'
 challenge_url: https://projects.ecoforecast.org/usgsrc4cast-ci
 github_repo: eco4cast/usgsrc4cast-ci
 target_groups:

--- a/targets/_targets.R
+++ b/targets/_targets.R
@@ -8,9 +8,21 @@ tar_option_set(packages = c("dataRetrieval",
                             "tidyverse"))
 
 source("src/download_nwis_data.R")
+source("src/s3_utils.R")
 
 # End this file with a list of target objects.
 list(
+
+  tar_target(
+    config_file,
+    "../challenge_configuration.yaml",
+    format = "file"
+  ),
+
+  tar_target(
+    config,
+    yaml::read_yaml(config_file)
+  ),
 
   tar_target(
     site_list_file,
@@ -125,8 +137,8 @@ list(
                site_id = paste0("USGS-", site_id),
                project_id = "usgsrc4cast",
                duration = "P1D") %>%
-        select(datetime, site_id, #project_id, duration,
-               variable, observation)
+        select(project_id, site_id, datetime,
+               duration, variable, observation)
       write_csv(out, file = out_file)
       return(out_file)
     },
@@ -134,8 +146,11 @@ list(
   ),
 
   tar_target(
-    push_to_data_repo,
-    "fill_in"
+    push_to_targets_s3,
+    push_to_s3(
+      config = config,
+      local_file_name = all_historic_data_csv,
+      s3_file_name = "aquatics-targets.csv.gz")
   )
 
 )

--- a/targets/_targets.R
+++ b/targets/_targets.R
@@ -150,7 +150,7 @@ list(
     push_to_s3(
       config = config,
       local_file_name = all_historic_data_csv,
-      s3_file_name = "aquatics-targets.csv.gz")
+      s3_file_name = config$targets_file_name)
   )
 
 )

--- a/targets/src/s3_utils.R
+++ b/targets/src/s3_utils.R
@@ -1,0 +1,30 @@
+
+#' helper function for pushing file to s3
+#'
+#' @param config configuration file of the challenge
+#' @param local_file_name targets file name
+#' @param s3_file_name file to write to s3 #'
+push_to_s3 <- function(
+    config,
+    local_file_name,
+    s3_file_name
+){
+
+  targets <- read_csv(local_file_name)
+  # duration hard coded for now
+  bucket_path <- glue::glue("{config$targets_bucket}/project_id={config$project_id}/duration=P1D")
+
+  s3 <- arrow::s3_bucket(bucket_path,
+                         endpoint_override = config$endpoint,
+                         access_key = Sys.getenv("OSN_KEY"),
+                         secret_key = Sys.getenv("OSN_SECRET"))
+
+  sink <- s3$path(s3_file_name)
+
+  # write to s3
+  arrow::write_csv_arrow(x = targets,
+                         sink = sink)
+
+  return(sink)
+}
+


### PR DESCRIPTION
This [runs as expected](https://github.com/eco4cast/usgsrc4cast-ci/actions/runs/7293954078) and pushes targets file to S3. 

I can also read the file from S3 locally; e.g., 
```
read_csv("https://sdsc.osn.xsede.org/bio230014-bucket01/challenges/targets/project_id=usgsrc4cast/duration=P1D/river-chl-targets.csv.gz") 

# A tibble: 19,441 × 6
   project_id  site_id       datetime   duration variable observation
   <chr>       <chr>         <date>     <chr>    <chr>          <dbl>
 1 usgsrc4cast USGS-01463500 2017-02-17 P1D      chla             2.8
 2 usgsrc4cast USGS-01463500 2017-02-18 P1D      chla             2.7
 3 usgsrc4cast USGS-01463500 2017-02-19 P1D      chla             3.1
```