### PR TITLE
Show all-time aggregated scores on performance dashboard

### DIFF
--- a/dashboard/performance.qmd
+++ b/dashboard/performance.qmd
@@ -48,16 +48,11 @@ df_P1D <- arrow::open_dataset("../cache/summaries/duration=P1D") |>
 ```
 
 ```{r}
-cutoff <- Sys.Date() - lubridate::days(30)
 df_P1D_scores <- arrow::open_dataset("../cache/scores/duration=P1D") |>
   left_join(sites, by = "site_id") |>
   mutate(reference_datetime = lubridate::as_datetime(reference_datetime),
          datetime = lubridate::as_datetime(datetime)) |>
-  filter(reference_datetime > cutoff) |>
   collect()
-
-
-cutoff <- Sys.Date() - lubridate::days(365)
 
 
 ref <- Sys.Date() - lubridate::days(30)
@@ -76,9 +71,11 @@ ex_P1D <- df_P1D_scores |>
 ```
 
 ```{r}
-#Best models
+#Best models (based on last 30 days)
+best_cutoff <- Sys.Date() - lubridate::days(30)
 
 best_P1D_scores <- df_P1D_scores |>
+  filter(reference_datetime > best_cutoff) |>
   summarise(score = mean(crps, na.rm = TRUE), .by = c("model_id","variable")) |>
   arrange(variable, score) |>
   group_by(variable) |>
@@ -134,7 +131,7 @@ Average skill scores of each model across all sites.\
 
 Scores are shown by reference date and forecast horizon (in days).\
 
-Scores are averaged across all submissions of the model with a given horizon or a given `reference_datetime` using submissions made since `r cutoff`.\
+Scores are averaged across all submissions of the model with a given horizon or a given `reference_datetime` using all available scored submissions.\
 
 Learn about the continous ranked probablity score [here](https://projects.ecoforecast.org/neon4cast-docs/Evaluation.html)
 


### PR DESCRIPTION
## Summary

- Remove the 30-day cutoff filter on `df_P1D_scores` so the aggregated leaderboard plots display model performance across all available scored data
- Retain 30-day window for "best models" selection in the recent forecasts section (top 5 ranking)
- Update descriptive text to reflect the change

## Review plan

- [x] Verify `leaderboard_plots()` renders correctly with the larger dataset (no performance issues)
- [x] Confirm the "Most recent forecasts" section still shows only top 5 models from last 30 days
- [x] Check that the aggregated scores plots (by model, by reference_datetime, by horizon) look reasonable with full history

🤖 Generated with [Claude Code](https://claude.com/claude-code)