### PR TITLE
Drop docker create options for ARC kubernetes container mode

### DIFF
--- a/.github/workflows/drivers_stage1.yaml
+++ b/.github/workflows/drivers_stage1.yaml
@@ -14,7 +14,6 @@ jobs:
     container:
       image: eco4cast/rocker-neon4cast:latest
       # limit memory to <= 45GB
-      options: --memory 40g
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       OSN_KEY: ${{ secrets.OSN_KEY }}

--- a/.github/workflows/drivers_stage3.yaml
+++ b/.github/workflows/drivers_stage3.yaml
@@ -14,7 +14,6 @@ jobs:
     container:
       image: eco4cast/rocker-neon4cast:latest
       # limit memory to <= 45GB
-      options: --memory 40g
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       OSN_KEY: ${{ secrets.OSN_KEY }}


### PR DESCRIPTION
Prepares these workflows for the cirrus runner moving from privileged
Docker-in-Docker to ARC's `containerMode: kubernetes`, where job containers run
as sibling Kubernetes pods instead of Docker containers. That removes the
privileged container from the runner pod, which today means any job on this
runner can escape to root on the cluster's only node.

`runs-on` and `container:` are unchanged — the custom image still works exactly
as before, and a job container is in fact now required. The only removal is the
`options:` field: the Kubernetes container hooks do not support Docker create
options.
https://github.com/actions/runner-container-hooks/blob/main/packages/k8s/README.md

The memory caps are not lost, they move up a layer. `--memory 45g` / `--memory
40g` become `resources.limits.memory` and `--user root` becomes
`securityContext.runAsUser: 0`, both in the runner's hook pod template. This is
strictly better: a Docker `--memory` flag is invisible to the Kubernetes
scheduler, whereas a pod limit is both enforced and schedulable.

**Merge timing matters.** Between merging this and the cluster switching to
kubernetes mode, jobs run under dind with no memory cap. Please merge only
immediately before the cluster-side change, not well ahead of it.