### PR TITLE
Fix malformed describedby link in STAC collections (#111)

### DIFF
--- a/challenge_configuration.yaml
+++ b/challenge_configuration.yaml
@@ -93,4 +93,6 @@ catalog_config:
   citation_text: "Thomas, R.Q., C. Boettiger, C.C. Carey, M.C. Dietze, L.R. Johnson, M.A. Kenney, J.S. Mclachlan, J.A. Peters, E.R. Sokol, J.F. Weltzin, A. Willson, W.M. Woelmer, and Challenge Contributors. 2023. The NEON Ecological Forecasting Challenge. Frontiers in Ecology and Environment 21: 112-113."
   dashboard_url: "https://projects.ecoforecast.org/usgsrc4cast-ci/"
   dashboard_title: "EFI-USGS River Chlorophyll Forecast Challenge Dashboard"
+  documentation_url: "https://projects.ecoforecast.org/usgsrc4cast-docs/"
+  catalog_title: "EFI-USGS River Chlorophyll Forecasting Challenge"
   site_metadata_url: 'https://raw.githubusercontent.com/eco4cast/usgsrc4cast-ci/main/USGS_site_metadata.csv'


### PR DESCRIPTION
Fixes #111.

## Root cause

The reported pystac error —

> HREF: 'https://raw.githubusercontent.com/eco4cast/usgsrc4cast-ci/main/catalog/forecasts/collection.json' does not resolve to a STAC object

— is **not** caused by the `../catalog.json` root/parent links (those are identical to `neon4cast-catalog` and resolve correctly). The actual failure is that four collections (`forecasts`, `scores`, `summaries`, `noaa_forecasts`) contain a malformed `describedby` link:

```json
{ "rel": "describedby", "href": {}, "title": {}, "type": "text/html" }
```

pystac chokes on the empty-object `href` (`'dict' object has no attribute 'lower'` in `safe_urlparse`), so the collection "does not resolve to a STAC object".

`stac4cast::build_forecast_scores()` builds that link from `catalog_config$documentation_url` and `catalog_config$catalog_title`. Those keys were absent from `challenge_configuration.yaml`, so they serialized to `{}`. `neon4cast-ci` defines both keys, which is why its catalog validates.

## Fix

Add the two missing keys under `catalog_config`:

```yaml
documentation_url: "https://projects.ecoforecast.org/usgsrc4cast-docs/"
catalog_title: "EFI-USGS River Chlorophyll Forecasting Challenge"
```

The next catalog rebuild will emit valid `describedby` links and the catalog will pass validation from the parent `challenge-catalogs`.
