### PR TITLE
Add CA DWR Delta sites to dashboard docs

### DIFF
--- a/dashboard/R/build_dashboard_sites.R
+++ b/dashboard/R/build_dashboard_sites.R
@@ -7,12 +7,19 @@ project_sites$site_lat_lon <- lapply(1:nrow(project_sites), function(i) c(projec
 
 iterator_list <- 1:nrow(project_sites)
 
+# Label each site by its data-providing agency so the map can group USGS and
+# CA DWR (CDEC/EDI) sites separately. Falls back to "USGS" if agency_cd is absent.
+site_partner <- function(agency_cd) {
+  if (is.na(agency_cd)) return("USGS")
+  if (agency_cd == "CA-DWR") return("CA DWR") else return("USGS")
+}
+
 site_name_coords <- purrr::map(iterator_list, function(i)
   list(
    "type" = "Feature",
    "properties" = list(
      "site_id" = project_sites$site_id[i],
-     "Partner" = "USGS",
+     "Partner" = site_partner(project_sites$agency_cd[i]),
      "n" =  5 ),
    "geometry" = list(
      "type" = "Point",

--- a/dashboard/index.qmd
+++ b/dashboard/index.qmd
@@ -1,23 +1,47 @@
 ---
 title: "EFI-USGS River Chlorophyll Forecasting Challenge"
-editor: 
-  markdown: 
+editor:
+  markdown:
     wrap: 72
 ---
 
 We invite you to submit forecasts!
 
-The EFI-USGS River Chlorophyll Forecasting Challenge is an open platform for the ecological and data science communities to forecast data from [the U.S. Geological Survey (USGS)](https://www.usgs.gov/) before they are collected.
+The EFI-USGS River Chlorophyll Forecasting Challenge is an open platform
+for the ecological and data science communities to forecast data from
+[the U.S. Geological Survey (USGS)](https://www.usgs.gov/) before they
+are collected.
 
-The Challenge is hosted by the [Ecological Forecasting Initiative Research Coordination Network](https://ecoforecast.org) and sponsored by the U.S. National Science Foundation. This challenge is co-hosted by the [USGS Proxies Project](https://www.usgs.gov/mission-areas/water-resources/science/proxies-project), an effort supported by the Water Mission Area Water Quality Processes program to develop estimation methods for per- and polyfluoroalkyl substances (PFAS), harmful algal blooms (HABs), and 12 elements of concern, at multiple spatial and temporal scales.
+The Challenge is hosted by the [Ecological Forecasting Initiative
+Research Coordination Network](https://ecoforecast.org) and sponsored by
+the U.S. National Science Foundation. This challenge is co-hosted by the
+[USGS Proxies
+Project](https://www.usgs.gov/mission-areas/water-resources/science/proxies-project),
+an effort supported by the Water Mission Area Water Quality Processes
+program to develop estimation methods for per- and polyfluoroalkyl
+substances (PFAS), harmful algal blooms (HABs), and 12 elements of
+concern, at multiple spatial and temporal scales.
 
 ## Why a forecasting challenge?
 
-Our vision is to use forecasts to advance theory and to support natural resource management. We can begin to realize this vision by creating and analyzing a catalog of forecasts from a range of ecological systems, spatiotemporal scales, and environmental gradients. 
+Our vision is to use forecasts to advance theory and to support natural
+resource management. We can begin to realize this vision by creating and
+analyzing a catalog of forecasts from a range of ecological systems,
+spatiotemporal scales, and environmental gradients.
 
-Our forecasting challenge is a platform for the ecological and data science communities to advance skills in forecasting ecological systems and for generating forecasts that contribute to a synthetic understanding of patterns of environmental predictability.  Rewards for contributing are skill advancement, joy, and potential involvement in manuscripts. We do not currently crown winner nor offer financial awards.
+Our forecasting challenge is a platform for the ecological and data
+science communities to advance skills in forecasting ecological systems
+and for generating forecasts that contribute to a synthetic
+understanding of patterns of environmental predictability. Rewards for
+contributing are skill advancement, joy, and potential involvement in
+manuscripts. We do not currently crown winner nor offer financial
+awards.
 
-The original [NEON forecasting challenge](https://projects.ecoforecast.org/neon4cast-ci/) has been [an excellent focal project in university courses](https://www.neonscience.org/impact/observatory-blog/efi-neon-forecasting-challenge-classroom) and this EFI-USGS challenge could be used as classroom projects as well. 
+The original [NEON forecasting
+challenge](https://projects.ecoforecast.org/neon4cast-ci/) has been [an
+excellent focal project in university
+courses](https://www.neonscience.org/impact/observatory-blog/efi-neon-forecasting-challenge-classroom)
+and this EFI-USGS challenge could be used as classroom projects as well.
 
 <br /> <br />
 
@@ -47,17 +71,17 @@ most_recent_targets <- arrow::open_csv_dataset(s3_targets,
                                       variable = arrow::string(),
                                       observation = arrow::float()),
                                     skip = 1) |>
-  filter(project_id == config$project_id) |> 
+  filter(project_id == config$project_id) |>
     summarize(max = max(datetime),
               min = min(datetime),
-              n = n_distinct(variable)) |> 
+              n = n_distinct(variable)) |>
     mutate(max = lubridate::as_date(max),
-           min = lubridate::as_date(min)) |> 
+           min = lubridate::as_date(min)) |>
     dplyr::collect()
 
-#unique_forecasted_targets <- arrow::open_dataset("../cache/duration=P1D") |> 
-#  dplyr::distinct(variable) |> count() |> 
-#    dplyr::collect() |> 
+#unique_forecasted_targets <- arrow::open_dataset("../cache/duration=P1D") |>
+#  dplyr::distinct(variable) |> count() |>
+#    dplyr::collect() |>
 #    pull(n)
 
 last_updated <- Sys.Date()
@@ -68,28 +92,28 @@ last_updated <- Sys.Date()
 layout_column_wrap(
   width = "250px",
   value_box(
-    title = "Total forecasts submitted to the EFI-USGS Challenge", 
+    title = "Total forecasts submitted to the EFI-USGS Challenge",
     value = n_forecasts,
     showcase = bs_icon("graph-up"),
-    theme_color = "success" 
+    theme_color = "success"
   ),
   value_box(
-    title = "Most recent data for model training", 
+    title = "Most recent data for model training",
     value = most_recent_targets$max,
     showcase = bs_icon("bullseye"),
-    theme_color = "info" 
+    theme_color = "info"
   ),
     value_box(
-    title = "Number of years of data for model training", 
+    title = "Number of years of data for model training",
     value = round(as.numeric(most_recent_targets$max - most_recent_targets$min) /365, 2),
     showcase = bs_icon("bullseye"),
-    theme_color = "info" 
+    theme_color = "info"
   ),
     value_box(
-    title = "Number of variables being forecasted", 
+    title = "Number of variables being forecasted",
     value = most_recent_targets$n,
     showcase = bs_icon("clipboard-data"),
-    theme_color = "success" 
+    theme_color = "success"
   )
 )
 
@@ -99,29 +123,39 @@ layout_column_wrap(
 
 ## The Challenge is a platform
 
-Our platform is designed to empower you to contribute by providing target data, numerical weather forecasts, and tutorials.  We automatically score your forecasts using the latest USGS data.  All forecasts and scores are publicly available through cloud storage and discoverable through our catalog.
+Our platform is designed to empower you to contribute by providing
+target data, numerical weather forecasts, and tutorials. We
+automatically score your forecasts using the latest USGS data. All
+forecasts and scores are publicly available through cloud storage and
+discoverable through our catalog.
 
-![The NEON Ecological Forecasting Challenge platform from Thomas et al. 2023](img/workflow.png){fig-align="center"}
-<br /> <br />
+![The NEON Ecological Forecasting Challenge platform from Thomas et al.
+2023](img/workflow.png){fig-align="center"} <br /> <br />
 
 Figure from [Thomas et al. 2023](https://doi.org/10.1002/fee.2616)
 
 ## Contact
 
-eco4cast.initiative@gmail.com and jzwart@usgs.gov
+eco4cast.initiative\@gmail.com and jzwart\@usgs.gov
 
 ## Acknowledgements
 
-Thomas, R. Q., Boettiger, C., Carey, C. C., Dietze, M. C., Johnson, L. R., Kenney, M. A., et al. (2023). The NEON Ecological Forecasting Challenge. Frontiers in Ecology and the Environment, 21(3), 112–113. [https://doi.org/10.1002/fee.2616](https://doi.org/10.1002/fee.2616)
-<br /> <br /> 
-We thank the EFI community for feedback on the design of the Challenge. This material is based upon work supported by the National
-Science Foundation under Grant DEB-1926388.
-<br /> <br />
-<!--
+Thomas, R. Q., Boettiger, C., Carey, C. C., Dietze, M. C., Johnson, L.
+R., Kenney, M. A., et al. (2023). The NEON Ecological Forecasting
+Challenge. Frontiers in Ecology and the Environment, 21(3), 112–113.
+<https://doi.org/10.1002/fee.2616> <br /> <br /> We thank the EFI
+community for feedback on the design of the Challenge. This material is
+based upon work supported by the National Science Foundation under Grant
+DEB-1926388. <br /> <br /> <!--
 DRAFT — CA DWR acknowledgment pending review/sign-off by CA DWR collaborators.
 Framing: data provider + collaborator (not co-host). Do not publish to `main`
 until wording is approved.
--->
-We gratefully acknowledge the California Department of Water Resources (CA DWR) as a collaborator and data provider for the five Sacramento–San Joaquin Delta chlorophyll-a sites. These data are made available through CA DWR's [Environmental Data Initiative (EDI) data releases](https://portal.edirepository.org/nis/mapbrowse?scope=edi&identifier=1177), the [Water Data Library](https://data.cnra.ca.gov/), and the [California Data Exchange Center (CDEC)](https://cdec.water.ca.gov/). See [Data sources and quality](targets.qmd#sec-data-sources) for details.
-<br /> <br />
-Page last updated on `r Sys.Date()`
+--> We gratefully acknowledge the California Department of Water
+Resources (CA DWR) as a collaborator and data provider for the five
+Sacramento–San Joaquin Delta chlorophyll-a sites. These data are made
+available through CA DWR's [Environmental Data Initiative (EDI) data
+releases](https://portal.edirepository.org/nis/mapbrowse?scope=edi&identifier=1177),
+the [Water Data Library](https://data.cnra.ca.gov/), and the [California
+Data Exchange Center (CDEC)](https://cdec.water.ca.gov/). See [Data
+sources and quality](targets.qmd#sec-data-sources) for details. <br />
+<br /> Page last updated on `r Sys.Date()`

--- a/dashboard/index.qmd
+++ b/dashboard/index.qmd
@@ -116,5 +116,12 @@ Thomas, R. Q., Boettiger, C., Carey, C. C., Dietze, M. C., Johnson, L. R., Kenne
 <br /> <br /> 
 We thank the EFI community for feedback on the design of the Challenge. This material is based upon work supported by the National
 Science Foundation under Grant DEB-1926388.
-<br /> <br /> 
+<br /> <br />
+<!--
+DRAFT — CA DWR acknowledgment pending review/sign-off by CA DWR collaborators.
+Framing: data provider + collaborator (not co-host). Do not publish to `main`
+until wording is approved.
+-->
+We gratefully acknowledge the California Department of Water Resources (CA DWR) as a collaborator and data provider for the five Sacramento–San Joaquin Delta chlorophyll-a sites. These data are made available through CA DWR's [Environmental Data Initiative (EDI) data releases](https://portal.edirepository.org/nis/mapbrowse?scope=edi&identifier=1177), the [Water Data Library](https://data.cnra.ca.gov/), and the [California Data Exchange Center (CDEC)](https://cdec.water.ca.gov/). See [Data sources and quality](targets.qmd#sec-data-sources) for details.
+<br /> <br />
 Page last updated on `r Sys.Date()`

--- a/dashboard/instructions.qmd
+++ b/dashboard/instructions.qmd
@@ -1,8 +1,8 @@
 ---
 title: "How to forecast"
 number-sections: true
-editor: 
-  markdown: 
+editor:
+  markdown:
     wrap: sentence
 ---
 
@@ -11,7 +11,7 @@ editor:
 We provide an overview of the steps for submitting with the details below:
 
 1)  Explore the [data](targets.qmd#sec-targets) (e.g., targets) and build your forecast model.
-2)  Register and describe your model at <https://forms.gle/kg2Vkpho9BoMXSy57>. You are not required to register if your forecast submission uses the word "example" in your model_id". Any forecasts with "example" in the model_id will not be used in forecast evaluation analyses. Use `usgsrc4cast` as the challenge you are registering for. 
+2)  Register and describe your model at <https://forms.gle/kg2Vkpho9BoMXSy57>. You are not required to register if your forecast submission uses the word "example" in your model_id". Any forecasts with "example" in the model_id will not be used in forecast evaluation analyses. Use `usgsrc4cast` as the challenge you are registering for.
 3)  Generate a forecast!
 4)  Write the forecast output to a file that follows our standardized format (described below).
 5)  Submit your forecast using an R or python function (provided below).
@@ -21,7 +21,7 @@ We provide an overview of the steps for submitting with the details below:
 
 ### All forecasting approaches are welcome
 
-We encourage you to use any modeling approach to make a prediction about the future conditions at any of the USGS sites. 
+We encourage you to use any modeling approach to make a prediction about the future conditions at any of the USGS sites.
 
 ### Must include uncertainty
 
@@ -53,44 +53,46 @@ It also includes the use of a custom Docker Container for [R (eco4cast/rocker-ne
 ## You can forecast at any of the USGS sites
 
 If are you are getting started, we recommend a set of [focal sites](targets.qmd#sec-starting-sites).
-You are also welcome to submit forecasts to all  or a subset of USGS sites . More information about USGS sites can be found in the [site metadata](https://radiantearth.github.io/stac-browser/#/external/raw.githubusercontent.com/eco4cast/usgsrc4cast-ci/main/catalog/sites/collection.json) and on USGS's [website](https://dashboard.waterdata.usgs.gov/app/nwd/en/)
+You are also welcome to submit forecasts to all or a subset of USGS sites .
+More information about USGS sites can be found in the [site metadata](https://radiantearth.github.io/stac-browser/#/external/raw.githubusercontent.com/eco4cast/usgsrc4cast-ci/main/catalog/sites/collection.json) and on USGS's [website](https://dashboard.waterdata.usgs.gov/app/nwd/en/)
 
 ## Forecast file format
 
 The file is a csv format with the following columns:
 
--   `project_id`: use `usgsrc4cast`
+- `project_id`: use `usgsrc4cast`
 
--   `model_id`: the short name of the model defined as the model_id in your registration. The model_id should have no spaces.
-    `model_id` should reflect a method to forecast one or a set of target variables and must be unique to the `usgsrc4cast` challenge.
+- `model_id`: the short name of the model defined as the model_id in your registration.
+  The model_id should have no spaces.
+  `model_id` should reflect a method to forecast one or a set of target variables and must be unique to the `usgsrc4cast` challenge.
 
--   `datetime`: forecast timestamp.
-    Format `%Y-%m-%d %H:%M:%S` with UTC as the time zone.
-    Forecasts submitted with a `%Y-%m-%d` format will be converted to a full datetime assuming UTC mid-night.
+- `datetime`: forecast timestamp.
+  Format `%Y-%m-%d %H:%M:%S` with UTC as the time zone.
+  Forecasts submitted with a `%Y-%m-%d` format will be converted to a full datetime assuming UTC mid-night.
 
--   `reference_datetime`: The start of the forecast; this should be 0 times steps in the future.
-    There should only be one value of `reference_datetime` in the file.
-    Format is `%Y-%m-%d %H:%M:%S` with UTC as the time zone.
-    Forecasts submitted with a `%Y-%m-%d` format will be converted to a full datetime assuming UTC mid-night.
+- `reference_datetime`: The start of the forecast; this should be 0 times steps in the future.
+  There should only be one value of `reference_datetime` in the file.
+  Format is `%Y-%m-%d %H:%M:%S` with UTC as the time zone.
+  Forecasts submitted with a `%Y-%m-%d` format will be converted to a full datetime assuming UTC mid-night.
 
--   `duration`: the time-step of the forecast.
-    Use the value of `P1D` for a daily forecast, `P1W` for a weekly forecast, and `PT30M` for 30 minute forecast.
-    This value should match the duration of the target variable that you are forecasting.
-    Formatted as [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations)
+- `duration`: the time-step of the forecast.
+  Use the value of `P1D` for a daily forecast, `P1W` for a weekly forecast, and `PT30M` for 30 minute forecast.
+  This value should match the duration of the target variable that you are forecasting.
+  Formatted as [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations)
 
--   `site_id`: code for USGS site.
+- `site_id`: code for USGS site.
 
--   `family` name of the probability distribution that is described by the parameter values in the parameter column (see list below for accepted distribution).
-    An ensemble forecast as a family of `ensemble`.
-    See note below about family
+- `family` name of the probability distribution that is described by the parameter values in the parameter column (see list below for accepted distribution).
+  An ensemble forecast as a family of `ensemble`.
+  See note below about family
 
--   `parameter` the parameters for the distribution (see note below about the parameter column) or the number of the ensemble members.
-    For example, the parameters for a normal distribution are called `mu` and `sigma`.
+- `parameter` the parameters for the distribution (see note below about the parameter column) or the number of the ensemble members.
+  For example, the parameters for a normal distribution are called `mu` and `sigma`.
 
--   `variable`: standardized variable name.
-    It must match the variable name in the target file (e.g., `chla`).
+- `variable`: standardized variable name.
+  It must match the variable name in the target file (e.g., `chla`).
 
--   `prediction`: forecasted value for the parameter in the parameter column
+- `prediction`: forecasted value for the parameter in the parameter column
 
 ## Representing uncertainity
 
@@ -104,15 +106,15 @@ Parameteric forecasts for binary variables should use `bernoulli` as the family 
 
 The following names and parameterization of the distribution are currently supported (family: parameters):
 
--   `lognormal`: `mu`, `sigma`
--   `normal`: `mu`,`sigma`
--   `bernoulli`: `prob`
--   `beta`: `shape1`, `shape2`
--   `uniform`: `min`, `max`
--   `gamma`: `shape`, `rate`
--   `logistic`: `location`, `scale`
--   `exponential`: `rate`
--   `poisson`: `lambda`
+- `lognormal`: `mu`, `sigma`
+- `normal`: `mu`,`sigma`
+- `bernoulli`: `prob`
+- `beta`: `shape1`, `shape2`
+- `uniform`: `min`, `max`
+- `gamma`: `shape`, `rate`
+- `logistic`: `location`, `scale`
+- `exponential`: `rate`
+- `poisson`: `lambda`
 
 If you are submitting a forecast that is not in the supported list, we recommend using the ensemble format and sampling from your distribution to generate a set of ensemble members that represents your forecast distribution.
 
@@ -131,9 +133,10 @@ Here is an example of a forecast that uses a normal distribution:
 ```{r}
 df <- readr::read_csv("https://sdsc.osn.xsede.org/bio230014-bucket01/challenges/forecasts/raw/project_id=usgsrc4cast/T20240813050531_usgsrc4cast-2024-08-12-climatology.csv.gz", show_col_types = FALSE)
 ```
+
 ```{r}
-df |> 
-  head() |> 
+df |>
+  head() |>
   knitr::kable()
 ```
 
@@ -142,13 +145,13 @@ For an ensemble (or sample) forecast, the `family` column uses the word `ensembl
 ```{r}
 df <- readr::read_csv("https://sdsc.osn.xsede.org/bio230014-bucket01/challenges/forecasts/raw/project_id=usgsrc4cast/T20240813050531_usgsrc4cast-2024-08-12-persistenceRW.csv.gz", show_col_types = FALSE)
 ```
+
 ```{r}
-df |> 
-  dplyr::arrange(variable, site_id, datetime, parameter) |> 
-  head() |> 
+df |>
+  dplyr::arrange(variable, site_id, datetime, parameter) |>
+  head() |>
   knitr::kable()
 ```
-
 
 ## Submission process
 
@@ -172,25 +175,25 @@ Individual forecast files can be uploaded any time.
 Teams will submit their forecast csv files through an R function.
 The csv file can only contain one unique `model_id` and one unique `project_id`.
 
-The submit function is available using the following code in R 
+The submit function is available using the following code in R
 
 ```{r eval = FALSE}
-source("https://raw.githubusercontent.com/eco4cast/usgsrc4cast-ci/main/R/eco4cast-helpers/submit.R") 
+source("https://raw.githubusercontent.com/eco4cast/usgsrc4cast-ci/main/R/eco4cast-helpers/submit.R")
 source("https://raw.githubusercontent.com/eco4cast/usgsrc4cast-ci/main/R/eco4cast-helpers/forecast_output_validator.R")
 
 submit(forecast_file = "project_id-year-month-day-model_id.csv", project_id = "usgsrc4cast")
 ```
 
-or Python 
+or Python
 
 ```{python eval = FALSE}
 import requests
 
 def download_and_exec_script(url):
     response = requests.get(url)
-    response.raise_for_status() 
+    response.raise_for_status()
     exec(response.text, globals())
-    
+
 download_and_exec_script("https://raw.githubusercontent.com/eco4cast/usgsrc4cast-ci/main/python/submit.py")
 download_and_exec_script("https://raw.githubusercontent.com/eco4cast/usgsrc4cast-ci/main/python/forecast_output_validator.py")
 
@@ -202,20 +205,22 @@ submit(forecast_file = "project_id-year-month-day-model_id.csv", project_id = "u
 ### Processing
 
 After submission, our servers will process uploaded files by converting them to a [parquet format](https://radiantearth.github.io/stac-browser/#/external/raw.githubusercontent.com/eco4cast/usgsrc4cast-ci/main/catalog/forecasts/collection.json) on our public s3 storage.
-A `pub_datetime` column will be added that denotes when a forecast was submitted.  [Summaries](https://radiantearth.github.io/stac-browser/#/external/raw.githubusercontent.com/eco4cast/usgsrc4cast-ci/main/catalog/summaries/collection.json) are generated of the forecasts provide descriptive statistics of the forecast.  
+A `pub_datetime` column will be added that denotes when a forecast was submitted.
+[Summaries](https://radiantearth.github.io/stac-browser/#/external/raw.githubusercontent.com/eco4cast/usgsrc4cast-ci/main/catalog/summaries/collection.json) are generated of the forecasts provide descriptive statistics of the forecast.
 
 ### Evaluation
 
 All forecasts are scored daily using new data until the full horizon of the forecast has been scored.
-Forecasts are scored using the `crps` function in the [`scoringRules`](https://cran.r-project.org/web/packages/scoringRules/index.html) R package.  More information about the scoring metric can be found at [here](https://projects.ecoforecast.org/neon4cast-docs/Evaluation.html)
+Forecasts are scored using the `crps` function in the [`scoringRules`](https://cran.r-project.org/web/packages/scoringRules/index.html) R package.
+More information about the scoring metric can be found at [here](https://projects.ecoforecast.org/neon4cast-docs/Evaluation.html)
 
 ### Comparison
 
 Forecast performance can be compared to the performance of baseline models.
 We are automatically submitting the following baseline models:
 
--   `climatology`: the normal distribution (mean and standard deviation) of that day-of-year in the historical observations
--   `persistenceRW`: a random walk model that assumes no change in the mean behavior. The random walk is initialized using the most resent observation.
+- `climatology`: the normal distribution (mean and standard deviation) of that day-of-year in the historical observations
+- `persistenceRW`: a random walk model that assumes no change in the mean behavior. The random walk is initialized using the most resent observation.
 
 Our [forecast performance](performance.qmd#performance) page includes evaluations of all submitted models.
 

--- a/dashboard/sites.json
+++ b/dashboard/sites.json
@@ -127,6 +127,66 @@
         "type": "Point",
         "coordinates": [-74.7781, 40.2217]
       }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "site_id": "DWR-SJR",
+        "Partner": "CA DWR",
+        "n": 5
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-121.2651, 37.6793]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "site_id": "DWR-MLS",
+        "Partner": "CA DWR",
+        "n": 5
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-121.32, 37.95]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "site_id": "DWR-GLE",
+        "Partner": "CA DWR",
+        "n": 5
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-121.4349, 37.8203]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "site_id": "DWR-MHO",
+        "Partner": "CA DWR",
+        "n": 5
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-121.3833, 37.8762]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "site_id": "DWR-OH1",
+        "Partner": "CA DWR",
+        "n": 5
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-121.3312, 37.8076]
+      }
     }
   ]
 }

--- a/dashboard/targets.qmd
+++ b/dashboard/targets.qmd
@@ -1,7 +1,7 @@
 ---
 title: "What to forecast"
-editor: 
-  markdown: 
+editor:
+  markdown:
     wrap: sentence
 ---
 
@@ -15,8 +15,8 @@ target_metadata <- readr::read_csv("https://raw.githubusercontent.com/eco4cast/u
 ```
 
 ```{r echo = FALSE}
-target_metadata <- target_metadata |> 
-  rename(variable = `"official" targets name`) |> 
+target_metadata <- target_metadata |>
+  rename(variable = `"official" targets name`) |>
   select(variable, duration, class, Description, horizon, Latency)
 ```
 
@@ -28,14 +28,13 @@ The targets are updated as new USGS data are made available.
 
 This challenge focuses on forecasting river chlorophyll-a at select monitoring locations.
 Most sites are United States Geological Survey ([USGS](https://www.usgs.gov/)) stations.
-In addition, five sites in the Sacramento–San Joaquin Delta are contributed by the
-California Department of Water Resources ([CA DWR](https://water.ca.gov/)) — see
-[Data sources and quality](#sec-data-sources) below for how those data are assembled
-and quality-controlled. The links to targets files are included below.
+In addition, five sites in the Sacramento–San Joaquin Delta are contributed by the California Department of Water Resources ([CA DWR](https://water.ca.gov/)) — see [Data sources and quality](#sec-data-sources) below for how those data are assembled and quality-controlled.
+The links to targets files are included below.
 
 ## Where to start {#sec-starting-sites}
 
 <!-- If are you are getting started, we recommend the following focal sites for each of the five "themes". -->
+
 <!-- The first site in the list is the recommended starting site. -->
 
 <!-- -   Aquatics: `r aquatics_focal_sites` -->
@@ -50,12 +49,11 @@ More information about USGS sites can be found in the [site metadata](https://ra
 Information on the targets files for the river chlorophyll challenge is below.
 In the tables,
 
--   "duration" is the time-step of the variable where `P1D` is a daily mean.
+- "duration" is the time-step of the variable where `P1D` is a daily mean.
 
--   The "forecast horizon" is the number of days-ahead that we want you to forecast.
+- The "forecast horizon" is the number of days-ahead that we want you to forecast.
 
--   The "latency" is the time between data collection and data availability in the targets file
-
+- The "latency" is the time between data collection and data availability in the targets file
 
 ### River Chlorophyll
 
@@ -65,11 +63,11 @@ The river chlorophyll challenge invites you to forecast daily mean chlorophyll a
 
 ```{r echo = FALSE}
 url <- "https://sdsc.osn.xsede.org/bio230014-bucket01/challenges/targets/project_id=usgsrc4cast/duration=P1D/river-chl-targets.csv.gz"
-read_csv(url, show_col_types = FALSE) |> 
-  distinct(variable, duration) |> 
-  left_join(target_metadata, by = c("variable","duration")) |> 
-  filter(variable %in% c("chla")) |> 
-  select(-class) |> 
+read_csv(url, show_col_types = FALSE) |>
+  distinct(variable, duration) |>
+  left_join(target_metadata, by = c("variable","duration")) |>
+  filter(variable %in% c("chla")) |>
+  select(-class) |>
   knitr::kable()
 ```
 
@@ -97,24 +95,23 @@ aquatics_targets = pd.read_csv(url)
 The file contains the following columns
 
 ```{r echo = FALSE}
-aquatics_targets |> 
-  na.omit() |> 
-  head() |> 
+aquatics_targets |>
+  na.omit() |>
+  head() |>
   knitr::kable()
 ```
 
 and the time series for the focal sites
 
 ```{r}
-aquatics_targets |> 
-  filter(site_id %in% aquatics_focal_sites) |> 
+aquatics_targets |>
+  filter(site_id %in% aquatics_focal_sites) |>
   ggplot(aes(x = datetime, y = observation)) +
   geom_point() +
   facet_wrap(~site_id, scales = "free") +
-  theme_bw() + 
+  theme_bw() +
   ylab("Chlorophyll-a (ug/L)")
 ```
-
 
 ## Explore the sites
 
@@ -129,7 +126,7 @@ leaflet() %>%
   addTiles(group="OSM") %>%
   addProviderTiles(providers$Esri.WorldImagery, group="Imagery") %>%
   addProviderTiles(providers$Esri.WorldTopoMap, group="Topo Map") %>%
-  addLayersControl(baseGroups=c('Imagery','OSM', 'Topo Map')) |> 
+  addLayersControl(baseGroups=c('Imagery','OSM', 'Topo Map')) |>
   addMarkers(data  = sites, popup=~as.character(site_id), group = ~as.character(Partner), clusterOptions = markerClusterOptions())
 ```
 
@@ -146,53 +143,41 @@ site_list <- read_csv("../USGS_site_metadata.csv", show_col_types = FALSE) |>
 site_list |> knitr::kable()
 ```
 
+```{=html}
 <!--
 DRAFT — the CA DWR data-source description and acknowledgment below are pending
 review and sign-off by CA DWR collaborators. Do not merge to `main` (which
 publishes to GitHub Pages) until the wording is approved.
 -->
+```
 
 ## Data sources and quality {#sec-data-sources}
 
-Target chlorophyll-a observations come from two agencies, and the data pass
-through different levels of quality assurance depending on the source. When more
-than one source reports a value for the same site and day, the challenge keeps
-the value from the **highest-quality source available**.
+Target chlorophyll-a observations come from two agencies, and the data pass through different levels of quality assurance depending on the source.
+When more than one source reports a value for the same site and day, the challenge keeps the value from the **highest-quality source available**.
 
 ### USGS sites (10 sites)
 
-Observations are pulled from the USGS National Water Information System
-([NWIS](https://waterdata.usgs.gov/nwis)) — daily-value and unit-value chlorophyll
-records — and updated as new data are released. See the USGS
-[Water Data dashboard](https://dashboard.waterdata.usgs.gov/app/nwd/en/) for the
-underlying station data.
+Observations are pulled from the USGS National Water Information System ([NWIS](https://waterdata.usgs.gov/nwis)) — daily-value and unit-value chlorophyll records — and updated as new data are released.
+See the USGS [Water Data dashboard](https://dashboard.waterdata.usgs.gov/app/nwd/en/) for the underlying station data.
 
 ### CA DWR Delta sites (5 sites)
 
-The five Sacramento–San Joaquin Delta sites (`DWR-SJR`, `DWR-MLS`, `DWR-GLE`,
-`DWR-MHO`, `DWR-OH1`) are monitored by the California Department of Water
-Resources. Their chlorophyll-a data are assembled from up to three sources, in
-decreasing order of data quality:
+The five Sacramento–San Joaquin Delta sites (`DWR-SJR`, `DWR-MLS`, `DWR-GLE`, `DWR-MHO`, `DWR-OH1`) are monitored by the California Department of Water Resources.
+Their chlorophyll-a data are assembled from up to three sources, in decreasing order of data quality:
 
 | Source | Quality | Update cadence | Role in the target record |
-|--------|---------|----------------|---------------------------|
-| **[EDI](https://portal.edirepository.org/nis/mapbrowse?packageid=edi.2180.2) data releases** | Reviewed / **QA-QC'd** | ~annual | Authoritative historical record; failed-QA values are set to `NA` by the data publisher. Feeds the long baseline used by climatology models. |
-| **[Water Data Library](https://data.cnra.ca.gov/) (WDL/CNRA)** | Reviewed / **QA-QC'd** | ~every 2 months | Extends the reviewed record past the latest EDI revision *(this layer is planned; not yet integrated).* |
-| **[CDEC](https://cdec.water.ca.gov/) real-time telemetry** | **Not QA-QC'd** (provisional) | daily | Keeps the most recent days current for scoring; may contain gaps or outliers until EDI/WDL catch up. |
+|---------------|---------------|----------------|----------------------------|
+| [**EDI**](https://portal.edirepository.org/nis/mapbrowse?packageid=edi.2180.2) **data releases** | Reviewed / **QA-QC'd** | \~annual | Authoritative historical record; failed-QA values are set to `NA` by the data publisher. Feeds the long baseline used by climatology models. |
+| [**Water Data Library**](https://data.cnra.ca.gov/) **(WDL/CNRA)** | Reviewed / **QA-QC'd** | \~every 2 months | Extends the reviewed record past the latest EDI revision *(this layer is planned; not yet integrated).* |
+| [**CDEC**](https://cdec.water.ca.gov/) **real-time telemetry** | **Not QA-QC'd** (provisional) | daily | Keeps the most recent days current for scoring; may contain gaps or outliers until EDI/WDL catch up. |
 
-**What is and isn't quality-controlled:** the deep historical record for these
-sites (roughly 2005–2025, depending on station) comes from the QA-QC'd EDI data
-releases published by CA DWR. The most recent tail of the record — the days more
-recent than the latest EDI release — comes from **CDEC real-time telemetry, which
-is provisional and not quality-controlled**. Those recent values are used so
-forecasts can be scored promptly, and are progressively replaced by reviewed
-values as CA DWR publishes them.
+**What is and isn't quality-controlled:** the deep historical record for these sites (roughly 2005–2025, depending on station) comes from the QA-QC'd EDI data releases published by CA DWR. The most recent data in the record, or the days more recent than the latest EDI release, comes from CDEC real-time telemetry, which is provisional and not quality-controlled.
+Those recent values are used so forecasts can be scored promptly, and are progressively replaced by reviewed values as CA DWR publishes them.
 
 EDI data releases used:
 
 - **NCRO continuous water quality** (`DWR-GLE`, `DWR-MHO`, `DWR-OH1`): [`edi.2180.2`](https://portal.edirepository.org/nis/mapbrowse?packageid=edi.2180.2)
 - **EMP** (`DWR-SJR`): [`edi.1177.8`](https://portal.edirepository.org/nis/mapbrowse?scope=edi&identifier=1177&revision=8)
 
-`DWR-MLS` (McLeod Lake, Stockton) was installed in 2024 and is not yet in an EDI
-release, so its record is currently CDEC-only (provisional) until a longer,
-reviewed record becomes available.
+`DWR-MLS` (McLeod Lake, Stockton) was installed in 2024 and is not yet in an EDI release, so its record is currently CDEC-only (provisional) until a longer, reviewed record becomes available.

--- a/dashboard/targets.qmd
+++ b/dashboard/targets.qmd
@@ -26,7 +26,12 @@ The "targets" are time-series of United States Geological Survey ([USGS](https:/
 
 The targets are updated as new USGS data are made available.
 
-This challenge focuses on forecasting river chlorophyll-a at select USGS monitoring locations. The links to targets files are included below.
+This challenge focuses on forecasting river chlorophyll-a at select monitoring locations.
+Most sites are United States Geological Survey ([USGS](https://www.usgs.gov/)) stations.
+In addition, five sites in the Sacramento–San Joaquin Delta are contributed by the
+California Department of Water Resources ([CA DWR](https://water.ca.gov/)) — see
+[Data sources and quality](#sec-data-sources) below for how those data are assembled
+and quality-controlled. The links to targets files are included below.
 
 ## Where to start {#sec-starting-sites}
 
@@ -35,8 +40,8 @@ This challenge focuses on forecasting river chlorophyll-a at select USGS monitor
 
 <!-- -   Aquatics: `r aquatics_focal_sites` -->
 
-As you develop your forecasting skills and want to expand to more sites, the targets are available at all 10 USGS sites.
-You may also consider submitting forecasts to sites that match your interests or locality. 
+As you develop your forecasting skills and want to expand to more sites, the targets are available at all 15 sites (10 USGS sites and 5 CA DWR Delta sites).
+You may also consider submitting forecasts to sites that match your interests or locality.
 
 More information about USGS sites can be found in the [site metadata](https://radiantearth.github.io/stac-browser/#/external/raw.githubusercontent.com/eco4cast/usgsrc4cast-ci/main/catalog/sites/collection.json) and on USGS's [website](https://dashboard.waterdata.usgs.gov/app/nwd/en/)
 
@@ -56,7 +61,7 @@ In the tables,
 
 ![](https://d9-wret.s3.us-west-2.amazonaws.com/assets/palladium/production/s3fs-public/media/images/Millstone-hab1.png)
 
-The river chlorophyll challenge invites you to forecast daily mean chlorophyll at up to 10 USGS river sites.
+The river chlorophyll challenge invites you to forecast daily mean chlorophyll at up to 15 river sites — 10 USGS sites and 5 CA DWR sites in the Sacramento–San Joaquin Delta.
 
 ```{r echo = FALSE}
 url <- "https://sdsc.osn.xsede.org/bio230014-bucket01/challenges/targets/project_id=usgsrc4cast/duration=P1D/river-chl-targets.csv.gz"
@@ -132,10 +137,62 @@ leaflet() %>%
 The columns with "theme" names incidate whether that site is included in that theme's target file.
 
 ```{r echo = FALSE}
-site_list <- read_csv("../USGS_site_metadata.csv", show_col_types = FALSE) |> 
-  select(site_id, site_no, station_nm, site_url) 
+site_list <- read_csv("../USGS_site_metadata.csv", show_col_types = FALSE) |>
+  mutate(agency = ifelse(agency_cd == "CA-DWR", "CA DWR", "USGS")) |>
+  select(site_id, agency, site_no, station_nm, site_url)
 ```
 
 ```{r echo = FALSE}
 site_list |> knitr::kable()
 ```
+
+<!--
+DRAFT — the CA DWR data-source description and acknowledgment below are pending
+review and sign-off by CA DWR collaborators. Do not merge to `main` (which
+publishes to GitHub Pages) until the wording is approved.
+-->
+
+## Data sources and quality {#sec-data-sources}
+
+Target chlorophyll-a observations come from two agencies, and the data pass
+through different levels of quality assurance depending on the source. When more
+than one source reports a value for the same site and day, the challenge keeps
+the value from the **highest-quality source available**.
+
+### USGS sites (10 sites)
+
+Observations are pulled from the USGS National Water Information System
+([NWIS](https://waterdata.usgs.gov/nwis)) — daily-value and unit-value chlorophyll
+records — and updated as new data are released. See the USGS
+[Water Data dashboard](https://dashboard.waterdata.usgs.gov/app/nwd/en/) for the
+underlying station data.
+
+### CA DWR Delta sites (5 sites)
+
+The five Sacramento–San Joaquin Delta sites (`DWR-SJR`, `DWR-MLS`, `DWR-GLE`,
+`DWR-MHO`, `DWR-OH1`) are monitored by the California Department of Water
+Resources. Their chlorophyll-a data are assembled from up to three sources, in
+decreasing order of data quality:
+
+| Source | Quality | Update cadence | Role in the target record |
+|--------|---------|----------------|---------------------------|
+| **[EDI](https://portal.edirepository.org/nis/mapbrowse?packageid=edi.2180.2) data releases** | Reviewed / **QA-QC'd** | ~annual | Authoritative historical record; failed-QA values are set to `NA` by the data publisher. Feeds the long baseline used by climatology models. |
+| **[Water Data Library](https://data.cnra.ca.gov/) (WDL/CNRA)** | Reviewed / **QA-QC'd** | ~every 2 months | Extends the reviewed record past the latest EDI revision *(this layer is planned; not yet integrated).* |
+| **[CDEC](https://cdec.water.ca.gov/) real-time telemetry** | **Not QA-QC'd** (provisional) | daily | Keeps the most recent days current for scoring; may contain gaps or outliers until EDI/WDL catch up. |
+
+**What is and isn't quality-controlled:** the deep historical record for these
+sites (roughly 2005–2025, depending on station) comes from the QA-QC'd EDI data
+releases published by CA DWR. The most recent tail of the record — the days more
+recent than the latest EDI release — comes from **CDEC real-time telemetry, which
+is provisional and not quality-controlled**. Those recent values are used so
+forecasts can be scored promptly, and are progressively replaced by reviewed
+values as CA DWR publishes them.
+
+EDI data releases used:
+
+- **NCRO continuous water quality** (`DWR-GLE`, `DWR-MHO`, `DWR-OH1`): [`edi.2180.2`](https://portal.edirepository.org/nis/mapbrowse?packageid=edi.2180.2)
+- **EMP** (`DWR-SJR`): [`edi.1177.8`](https://portal.edirepository.org/nis/mapbrowse?scope=edi&identifier=1177&revision=8)
+
+`DWR-MLS` (McLeod Lake, Stockton) was installed in 2024 and is not yet in an EDI
+release, so its record is currently CDEC-only (provisional) until a longer,
+reviewed record becomes available.


### PR DESCRIPTION
Documents the five Sacramento–San Joaquin Delta chlorophyll-a sites contributed by CA DWR on the challenge dashboard.

## Changes
- **`dashboard/R/build_dashboard_sites.R`** — label map markers by `agency_cd` so CA DWR sites group separately from USGS on the leaflet map.
- **`dashboard/sites.json`** — regenerated with all 15 sites (10 USGS + 5 CA DWR).
- **`dashboard/targets.qmd`** — update site counts (10 → 15), add an `agency` column to the site table, and add a **"Data sources and quality"** section describing the EDI (QA-QC'd) → WDL → CDEC (provisional/not QC'd) sourcing for the DWR sites.
- **`dashboard/index.qmd`** — acknowledge CA DWR as a data provider and collaborator.

## ⚠️ Do not merge yet
The CA DWR acknowledgment and data-source wording are marked `DRAFT` (HTML comments in `index.qmd` and `targets.qmd`) and are **pending review and sign-off by CA DWR collaborators**. Merging to `main` publishes to GitHub Pages — hold until the wording is approved.
